### PR TITLE
feat: UI improvements for credential cards and ledger display

### DIFF
--- a/app/components/EnhancedCredentialFilter.tsx
+++ b/app/components/EnhancedCredentialFilter.tsx
@@ -28,6 +28,8 @@ import {
   getAvailableLedgerOptions,
   filterBundles,
   BundleWithLedger,
+  isProductionLedger,
+  isNonProductionLedger,
 } from '@/app/lib/data';
 import SimpleCredentialCard from './SimpleCredentialCard';
 import { useLanguage } from '@/app/contexts/Language';
@@ -328,38 +330,91 @@ export default function EnhancedCredentialFilter({ options }: EnhancedCredential
         <>
           {filteredBundles.length > 0 && (
             <>
-              {Object.entries(filteredGroupedBundles).map(([ledger, bundles]) => (
-                <Accordion key={ledger} defaultExpanded sx={{ mb: 2 }}>
-                  <AccordionSummary
-                    expandIcon={<ExpandMore />}
-                    aria-controls={`${ledger}-content`}
-                    id={`${ledger}-header`}
-                  >
-                    <Typography variant="h6" component="div">
-                      {bundles[0]?.ledgerDisplayName || ledger || 'Unknown Ledger'}
-                      <Chip
-                        label={bundles.length}
-                        size="small"
-                        sx={{ ml: 2 }}
-                        color="primary"
-                      />
-                    </Typography>
-                  </AccordionSummary>
-                  <AccordionDetails>
-                    <Grid container spacing={3}>
-                      {bundles.map((bundle) => (
-                        <Grid item xs={12} sm={6} md={4} lg={4} xl={3} key={bundle.id}>
-                          <SimpleCredentialCard
-                            bundle={bundle}
-                            onClick={() => handleBundleSelect(bundle)}
-                            language={language}
+              {Object.entries(filteredGroupedBundles)
+                .sort(([ledgerA], [ledgerB]) => {
+                  // Production ledgers first
+                  const aIsProd = isProductionLedger(ledgerA);
+                  const bIsProd = isProductionLedger(ledgerB);
+                  if (aIsProd && !bIsProd) return -1;
+                  if (!aIsProd && bIsProd) return 1;
+                  return 0;
+                })
+                .map(([ledger, bundles]) => {
+                  const isProd = isProductionLedger(ledger);
+                  return (
+                    <Accordion
+                      key={ledger}
+                      defaultExpanded={isProd}
+                      sx={{
+                        mb: 2,
+                        opacity: isProd ? 1 : 0.75,
+                        '& .MuiAccordionSummary-root': {
+                          minHeight: isProd ? 64 : 48,
+                          '& .MuiAccordionSummary-content': {
+                            my: isProd ? 1.5 : 1,
+                          }
+                        }
+                      }}
+                    >
+                      <AccordionSummary
+                        expandIcon={<ExpandMore />}
+                        aria-controls={`${ledger}-content`}
+                        id={`${ledger}-header`}
+                      >
+                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                          {!isProd && (
+                            <Chip
+                              label="TEST / DEV"
+                              size="small"
+                              sx={{
+                                height: 20,
+                                fontSize: '9px',
+                                fontWeight: 600,
+                                backgroundColor: 'warning.main',
+                                color: 'warning.contrastText',
+                                letterSpacing: '0.05em',
+                              }}
+                            />
+                          )}
+                          <Typography
+                            variant="h6"
+                            component="div"
+                            sx={{
+                              fontWeight: isProd ? 700 : 500,
+                              fontSize: isProd ? '1.1rem' : '0.95rem',
+                            }}
+                          >
+                            {bundles[0]?.ledgerDisplayName || ledger || 'Unknown Ledger'}
+                          </Typography>
+                          <Chip
+                            label={`${bundles.length} bundle${bundles.length !== 1 ? 's' : ''}`}
+                            size="small"
+                            sx={{
+                              ml: 1,
+                              height: isProd ? 24 : 20,
+                              fontSize: isProd ? '11px' : '10px',
+                              fontWeight: isProd ? 600 : 400,
+                            }}
+                            color={isProd ? 'primary' : 'default'}
                           />
+                        </Box>
+                      </AccordionSummary>
+                      <AccordionDetails>
+                        <Grid container spacing={3}>
+                          {bundles.map((bundle) => (
+                            <Grid item xs={12} sm={6} md={4} lg={4} xl={3} key={bundle.id}>
+                              <SimpleCredentialCard
+                                bundle={bundle}
+                                onClick={() => handleBundleSelect(bundle)}
+                                language={language}
+                              />
+                            </Grid>
+                          ))}
                         </Grid>
-                      ))}
-                    </Grid>
-                  </AccordionDetails>
-                </Accordion>
-              ))}
+                      </AccordionDetails>
+                    </Accordion>
+                  );
+                })}
             </>
           )}
         </>

--- a/app/components/GroupedIdDisplay.tsx
+++ b/app/components/GroupedIdDisplay.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Box, Typography, Link } from '@mui/material';
+import React, { useState } from 'react';
+import { Box, Typography, Link, Tooltip, IconButton, useTheme } from '@mui/material';
 import { constructExplorerUrl } from '@/app/lib/data';
 
 interface IdLedgerInfo {
@@ -15,6 +15,8 @@ interface GroupedIdDisplayProps {
   ledgerNormalized?: string;
   // Per-ID ledger mapping for correct explorer URLs in multi-ledger bundles
   idLedgerMap?: Record<string, IdLedgerInfo>;
+  // Optional max width to constrain the display (e.g., to match card width)
+  maxWidth?: number | string;
 }
 
 // Helper to get the ledger normalized value for a specific ID
@@ -25,13 +27,163 @@ function getIdLedgerNormalized(id: string, idLedgerMap?: Record<string, IdLedger
   return fallbackLedgerNormalized;
 }
 
+// Truncate long ID for display, showing first and last portions
+function truncateId(id: string, maxLength: number = 40): string {
+  if (id.length <= maxLength) return id;
+  const half = Math.floor((maxLength - 3) / 2);
+  return `${id.slice(0, half)}...${id.slice(-half)}`;
+}
+
+// Copy icon SVG
+const CopyIcon = () => (
+  <svg width="12" height="12" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M5.75 1.5C4.94 1.5 4.27 1.88 3.77 2.38L2.38 3.77C1.88 4.27 1.5 4.94 1.5 5.75V12.5C1.5 13.33 2.17 14 3 14H9.75C10.58 14 11.25 13.33 11.25 12.5V11.62L13.62 9.25C14.12 8.75 14.5 8.08 14.5 7.25V3C14.5 1.88 13.62 1 12.5 1H5.75ZM4.25 3.25L5.75 4.75L4.25 6.25L3 5V3.25H4.25ZM12 12H5V5.5L6.25 6.75L7.75 5.25L12 9.5V12Z" fill="currentColor"/>
+  </svg>
+);
+
+// Checkmark icon SVG
+const CheckIcon = () => (
+  <svg width="12" height="12" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M13.5 4.5L6 12L2.5 8.5L3.5 7.5L6 10L12.5 3.5L13.5 4.5Z" fill="currentColor"/>
+  </svg>
+);
+
+// External link icon SVG
+const ExternalLinkIcon = () => (
+  <svg width="10" height="10" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M2.5 9.5L9.5 2.5M9.5 2.5H4.5M9.5 2.5V7.5" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round"/>
+  </svg>
+);
+
+// Single ID row component to reduce duplication
+function IdRow({
+  id,
+  idLedgerNormalized,
+  ledgerNormalized,
+  idLedgerMap,
+  theme,
+  showCopy = true,
+}: {
+  id: string;
+  idLedgerNormalized: string | undefined;
+  ledgerNormalized: string | undefined;
+  idLedgerMap?: Record<string, IdLedgerInfo>;
+  theme: any;
+  showCopy?: boolean;
+}) {
+  const [copied, setCopied] = useState(false);
+  const resolvedLedger = idLedgerNormalized ?? ledgerNormalized;
+  const explorerUrl = constructExplorerUrl(id, resolvedLedger, [id]);
+  const { palette } = theme;
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(id);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch (err) {
+      console.error('Failed to copy:', err);
+    }
+  };
+
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+      <Tooltip title={id} arrow placement="top">
+        <Typography
+          variant="caption"
+          sx={{
+            fontSize: '11px',
+            fontFamily: '"JetBrains Mono", "Fira Code", monospace',
+            color: palette.text.secondary,
+            wordBreak: 'keep-all',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+            maxWidth: '100%',
+            flex: 1,
+            backgroundColor: palette.action.hover,
+            padding: '5px 10px',
+            borderRadius: '6px',
+            border: `1px solid ${palette.divider}`,
+            cursor: 'default',
+            transition: 'all 0.15s ease',
+            '&:hover': {
+              backgroundColor: palette.action.selected,
+            },
+          }}
+        >
+          {truncateId(id)}
+        </Typography>
+      </Tooltip>
+
+      {showCopy && (
+        <Tooltip title={copied ? 'Copied!' : 'Copy ID'} arrow placement="top">
+          <IconButton
+            size="small"
+            onClick={(e) => {
+              e.stopPropagation();
+              e.preventDefault();
+              handleCopy();
+            }}
+            sx={{
+              padding: '4px',
+              borderRadius: '4px',
+              color: copied ? 'success.main' : palette.primary.main,
+              backgroundColor: copied ? `${palette.success.main}15` : 'transparent',
+              transition: 'all 0.15s ease',
+              '&:hover': {
+                color: copied ? 'success.dark' : 'primary.dark',
+                backgroundColor: copied ? `${palette.success.main}25` : palette.action.hover,
+              },
+            }}
+          >
+            {copied ? <CheckIcon /> : <CopyIcon />}
+          </IconButton>
+        </Tooltip>
+      )}
+
+      {explorerUrl && (
+        <Link
+          href={explorerUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          sx={{
+            fontSize: '10px',
+            color: palette.text.secondary,
+            fontWeight: 500,
+            textDecoration: 'none',
+            whiteSpace: 'nowrap',
+            display: 'flex',
+            alignItems: 'center',
+            gap: 0.5,
+            padding: '4px 8px',
+            borderRadius: '4px',
+            transition: 'all 0.15s ease',
+            '&:hover': {
+              color: palette.text.primary,
+              backgroundColor: palette.action.hover,
+            },
+          }}
+        >
+          View
+          <ExternalLinkIcon />
+        </Link>
+      )}
+    </Box>
+  );
+}
+
 export default function GroupedIdDisplay({
   ids,
   showTitle = false,
   title = "Associated Identifiers",
   ledgerNormalized,
-  idLedgerMap
+  idLedgerMap,
+  maxWidth
 }: GroupedIdDisplayProps) {
+  const theme = useTheme();
+  const { palette } = theme;
+
   if (!ids || ids.length === 0) {
     return null;
   }
@@ -43,22 +195,24 @@ export default function GroupedIdDisplay({
   return (
     <Box
       sx={{
-        mt: 1.5,
-        p: 1.5,
-        backgroundColor: '#f8f9fa',
+        mt: 2,
+        p: 2,
+        maxWidth: maxWidth,
+        backgroundColor: palette.action.hover,
+        backdropFilter: 'blur(8px)',
         borderRadius: 2,
-        border: '1px solid #e9ecef',
-        boxShadow: '0 1px 3px rgba(0, 0, 0, 0.1)',
+        border: `1px solid ${palette.divider}`,
       }}
     >
       {showTitle && (
         <Typography
           variant="h6"
           sx={{
-            fontSize: '16px',
-            fontWeight: 500,
-            color: '#333',
-            mb: 2,
+            fontSize: '13px',
+            fontWeight: 600,
+            color: palette.text.secondary,
+            mb: 1.5,
+            letterSpacing: '0.02em',
           }}
         >
           {title}
@@ -68,60 +222,45 @@ export default function GroupedIdDisplay({
       {ids.length > 1 ? (
         <>
           {schemaIds.length > 0 && (
-            <Box sx={{ mb: credDefIds.length > 0 ? 2 : 0 }}>
-              <Typography
-                variant="caption"
-                sx={{
-                  fontSize: '9px',
-                  fontWeight: 600,
-                  color: '#6c757d',
-                  display: 'block',
-                  mb: 1,
-                  textTransform: 'uppercase',
-                }}
-              >
-                {schemaIds.length > 1 ? 'Schema IDs' : 'Schema ID'}
-              </Typography>
+            <Box sx={{ mb: credDefIds.length > 0 ? 1.5 : 0 }}>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+                <Box
+                  sx={{
+                    width: 18,
+                    height: 18,
+                    borderRadius: '4px',
+                    backgroundColor: palette.primary.main,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                  }}
+                >
+                  <Typography sx={{ fontSize: '10px', color: palette.primary.contrastText, fontWeight: 600 }}>S</Typography>
+                </Box>
+                <Typography
+                  variant="caption"
+                  sx={{
+                    fontSize: '10px',
+                    fontWeight: 500,
+                    color: palette.text.secondary,
+                    textTransform: 'uppercase',
+                    letterSpacing: '0.05em',
+                  }}
+                >
+                  {schemaIds.length > 1 ? 'Schema IDs' : 'Schema ID'}
+                </Typography>
+              </Box>
               {schemaIds.map((id, index) => {
                 const idLedgerNormalized = getIdLedgerNormalized(id, idLedgerMap, ledgerNormalized);
-                const explorerUrl = constructExplorerUrl(id, idLedgerNormalized, ids);
                 return (
-                  <Box key={index} sx={{ mb: index < schemaIds.length - 1 ? 1 : 0, display: 'flex', alignItems: 'center', gap: 1 }}>
-                    <Typography
-                      variant="caption"
-                      sx={{
-                        fontSize: '10px',
-                        fontFamily: 'monospace',
-                        color: '#212529',
-                        wordBreak: 'break-all',
-                        lineHeight: 1.4,
-                        backgroundColor: '#ffffff',
-                        padding: '6px 8px',
-                        borderRadius: 1,
-                        border: '1px solid #dee2e6',
-                        flex: 1,
-                      }}
-                    >
-                      {id}
-                    </Typography>
-                    {explorerUrl && (
-                      <Link
-                        href={explorerUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        sx={{
-                          fontSize: '9px',
-                          color: '#1976d2',
-                          textDecoration: 'underline',
-                          whiteSpace: 'nowrap',
-                          '&:hover': {
-                            color: '#1565c0',
-                          },
-                        }}
-                      >
-                        View →
-                      </Link>
-                    )}
+                  <Box key={index} sx={{ mb: index < schemaIds.length - 1 ? 0.75 : 0 }}>
+                    <IdRow
+                      id={id}
+                      idLedgerNormalized={idLedgerNormalized}
+                      ledgerNormalized={ledgerNormalized}
+                      idLedgerMap={idLedgerMap}
+                      theme={theme}
+                    />
                   </Box>
                 );
               })}
@@ -129,59 +268,44 @@ export default function GroupedIdDisplay({
           )}
           {credDefIds.length > 0 && (
             <Box>
-              <Typography
-                variant="caption"
-                sx={{
-                  fontSize: '9px',
-                  fontWeight: 600,
-                  color: '#6c757d',
-                  display: 'block',
-                  mb: 1,
-                  textTransform: 'uppercase',
-                }}
-              >
-                {credDefIds.length > 1 ? 'Credential Definition IDs' : 'Credential Definition ID'}
-              </Typography>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+                <Box
+                  sx={{
+                    width: 18,
+                    height: 18,
+                    borderRadius: '4px',
+                    backgroundColor: palette.primary.main,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                  }}
+                >
+                  <Typography sx={{ fontSize: '10px', color: palette.primary.contrastText, fontWeight: 600 }}>C</Typography>
+                </Box>
+                <Typography
+                  variant="caption"
+                  sx={{
+                    fontSize: '10px',
+                    fontWeight: 500,
+                    color: palette.text.secondary,
+                    textTransform: 'uppercase',
+                    letterSpacing: '0.05em',
+                  }}
+                >
+                  {credDefIds.length > 1 ? 'Credential Definition IDs' : 'Credential Definition ID'}
+                </Typography>
+              </Box>
               {credDefIds.map((id, index) => {
                 const idLedgerNormalized = getIdLedgerNormalized(id, idLedgerMap, ledgerNormalized);
-                const explorerUrl = constructExplorerUrl(id, idLedgerNormalized, ids);
                 return (
-                  <Box key={index} sx={{ mb: index < credDefIds.length - 1 ? 1 : 0, display: 'flex', alignItems: 'center', gap: 1 }}>
-                    <Typography
-                      variant="caption"
-                      sx={{
-                        fontSize: '10px',
-                        fontFamily: 'monospace',
-                        color: '#212529',
-                        wordBreak: 'break-all',
-                        lineHeight: 1.4,
-                        backgroundColor: '#ffffff',
-                        padding: '6px 8px',
-                        borderRadius: 1,
-                        border: '1px solid #dee2e6',
-                        flex: 1,
-                      }}
-                    >
-                      {id}
-                    </Typography>
-                    {explorerUrl && (
-                      <Link
-                        href={explorerUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        sx={{
-                          fontSize: '9px',
-                          color: '#1976d2',
-                          textDecoration: 'underline',
-                          whiteSpace: 'nowrap',
-                          '&:hover': {
-                            color: '#1565c0',
-                          },
-                        }}
-                      >
-                        View →
-                      </Link>
-                    )}
+                  <Box key={index} sx={{ mb: index < credDefIds.length - 1 ? 0.75 : 0 }}>
+                    <IdRow
+                      id={id}
+                      idLedgerNormalized={idLedgerNormalized}
+                      ledgerNormalized={ledgerNormalized}
+                      idLedgerMap={idLedgerMap}
+                      theme={theme}
+                    />
                   </Box>
                 );
               })}
@@ -190,60 +314,42 @@ export default function GroupedIdDisplay({
         </>
       ) : (
         <>
-          <Typography
-            variant="caption"
-            sx={{
-              fontSize: '9px',
-              fontWeight: 600,
-              color: '#6c757d',
-              display: 'block',
-              mb: 1,
-              textTransform: 'uppercase',
-            }}
-          >
-            {ids[0].includes(':3:CL:') ? 'Credential Definition ID' : 'Schema ID'}
-          </Typography>
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0.5 }}>
+            <Box
+              sx={{
+                width: 18,
+                height: 18,
+                borderRadius: '4px',
+                backgroundColor: palette.primary.main,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+              }}
+            >
+              <Typography sx={{ fontSize: '10px', color: palette.primary.contrastText, fontWeight: 600 }}>
+                {ids[0].includes(':3:CL:') ? 'C' : 'S'}
+              </Typography>
+            </Box>
             <Typography
               variant="caption"
               sx={{
                 fontSize: '10px',
-                fontFamily: 'monospace',
-                color: '#212529',
-                wordBreak: 'break-all',
-                lineHeight: 1.4,
-                backgroundColor: '#ffffff',
-                padding: '6px 8px',
-                borderRadius: 1,
-                border: '1px solid #dee2e6',
-                flex: 1,
+                fontWeight: 500,
+                color: palette.text.secondary,
+                textTransform: 'uppercase',
+                letterSpacing: '0.05em',
               }}
             >
-              {ids[0]}
+              {ids[0].includes(':3:CL:') ? 'Credential Definition ID' : 'Schema ID'}
             </Typography>
-            {(() => {
-              const idLedgerNormalized = getIdLedgerNormalized(ids[0], idLedgerMap, ledgerNormalized);
-              const explorerUrl = constructExplorerUrl(ids[0], idLedgerNormalized, ids);
-              return explorerUrl ? (
-                <Link
-                  href={explorerUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  sx={{
-                    fontSize: '9px',
-                    color: '#1976d2',
-                    textDecoration: 'underline',
-                    whiteSpace: 'nowrap',
-                    '&:hover': {
-                      color: '#1565c0',
-                    },
-                  }}
-                >
-                  View →
-                </Link>
-              ) : null;
-            })()}
           </Box>
+          <IdRow
+            id={ids[0]}
+            idLedgerNormalized={getIdLedgerNormalized(ids[0], idLedgerMap, ledgerNormalized)}
+            ledgerNormalized={ledgerNormalized}
+            idLedgerMap={idLedgerMap}
+            theme={theme}
+          />
         </>
       )}
     </Box>

--- a/app/components/SimpleCredentialCard.tsx
+++ b/app/components/SimpleCredentialCard.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState, useEffect } from 'react';
-import { Box, CircularProgress, Typography } from '@mui/material';
+import { Box, CircularProgress, Typography, Chip, useTheme } from '@mui/material';
 import { OverlayBundle } from '@hyperledger/aries-oca';
 import { CredentialExchangeRecord, CredentialPreviewAttribute, CredentialState } from '@aries-framework/core';
 import { fetchOverlayBundleData } from '@/app/lib/data';
@@ -9,6 +9,7 @@ import CredentialCard from './CredentialCard';
 import { BundleWithLedger } from '@/app/lib/data';
 import { BrandingProvider, useBrandingDispatch, ActionType } from '@/app/contexts/Branding';
 import GroupedIdDisplay from './GroupedIdDisplay';
+
 
 interface SimpleCredentialCardProps {
   bundle: BundleWithLedger;
@@ -222,19 +223,110 @@ function SimpleCredentialCardContent({ bundle, onClick, language = 'en' }: Simpl
   return (
     <Box
       sx={{
-        cursor: 'pointer',
+        position: 'relative',
         display: 'inline-block',
-        transition: 'transform 0.2s, box-shadow 0.2s',
-        '&:hover': {
-          transform: 'translateY(-2px)',
-          boxShadow: '0 4px 8px rgba(0, 0, 0, 0.15)',
-        }
+        width: 360,
       }}
-      onClick={onClick}
     >
-      <CredentialCard overlay={overlay || undefined} record={mockRecord || undefined} language={language} />
-      {/* All IDs below the card */}
-      <GroupedIdDisplay ids={bundle.ids || [bundle.id]} ledgerNormalized={bundle.ledgerNormalized} idLedgerMap={bundle.idLedgerMap} />
+      {/* OCA Card with shadow and click */}
+      <Box
+        onClick={onClick}
+        sx={{
+          cursor: 'pointer',
+          boxShadow: '0 2px 8px rgba(0, 0, 0, 0.15)',
+          borderRadius: 1,
+        }}
+      >
+        <CredentialCard overlay={overlay || undefined} record={mockRecord || undefined} language={language} />
+      </Box>
+      {/* Slim ID bar at bottom - just chips */}
+      <IdBar ids={bundle.ids || [bundle.id]} />
+    </Box>
+  );
+}
+
+// Mini ID bar component with copy chips
+function IdBar({ ids }: {
+  ids: string[];
+}) {
+  const theme = useTheme();
+  const { palette } = theme;
+  const [copied, setCopied] = useState<string | null>(null);
+
+  if (!ids || ids.length === 0) return null;
+
+  // Truncate ID for chip label - make it wider
+  const truncate = (id: string, len: number = 32) => id.length > len ? `${id.slice(0, len)}...` : id;
+
+  const handleCopy = async (id: string) => {
+    try {
+      await navigator.clipboard.writeText(id);
+      setCopied(id);
+      setTimeout(() => setCopied(null), 1500);
+    } catch (err) {
+      console.error('Failed to copy:', err);
+    }
+  };
+
+  const schemaIds = ids.filter(id => !id.includes(':3:CL:'));
+  const credDefIds = ids.filter(id => id.includes(':3:CL:'));
+
+  return (
+    <Box
+      sx={{
+        backgroundColor: palette.background.paper,
+        borderTop: `1px solid ${palette.divider}`,
+        borderRadius: '0 0 4px 4px',
+        px: 1.5,
+        py: 1,
+      }}
+    >
+      <Box sx={{ display: 'flex', gap: 0.75, flexWrap: 'wrap', alignItems: 'center' }}>
+        {schemaIds.map((id) => (
+          <Chip
+            key={id}
+            label={copied === id ? `✓ Copied!` : `SchemaID: ${truncate(id, 24)}`}
+            size="small"
+            onClick={(e) => { e.stopPropagation(); handleCopy(id); }}
+            sx={{
+              height: 28,
+              fontSize: '11px',
+              fontFamily: 'monospace',
+              fontWeight: copied === id ? 600 : 400,
+              backgroundColor: palette.action.hover,
+              border: `1px solid ${palette.divider}`,
+              color: palette.text.secondary,
+              cursor: 'pointer',
+              transition: 'all 0.15s ease',
+              '&:hover': {
+                backgroundColor: palette.action.selected,
+              },
+            }}
+          />
+        ))}
+        {credDefIds.map((id) => (
+          <Chip
+            key={id}
+            label={copied === id ? `✓ Copied!` : `CredDefID: ${truncate(id, 22)}`}
+            size="small"
+            onClick={(e) => { e.stopPropagation(); handleCopy(id); }}
+            sx={{
+              height: 28,
+              fontSize: '11px',
+              fontFamily: 'monospace',
+              fontWeight: copied === id ? 600 : 400,
+              backgroundColor: palette.action.hover,
+              border: `1px solid ${palette.divider}`,
+              color: palette.text.secondary,
+              cursor: 'pointer',
+              transition: 'all 0.15s ease',
+              '&:hover': {
+                backgroundColor: palette.action.selected,
+              },
+            }}
+          />
+        ))}
+      </Box>
     </Box>
   );
 }

--- a/app/lib/data.ts
+++ b/app/lib/data.ts
@@ -374,7 +374,7 @@ export async function fetchSchemaReadme(ocabundle: string): Promise<{
       if (isTimeout) {
         if (attempt < maxRetries) {
           // Exponential backoff: 2s, 4s, 8s with jitter
-          const delay = (Math.pow(2, attempt) * 1000) + Math.random() * 1000;
+          const delay = (Math.pow(2, attempt + 1) * 1000) + Math.random() * 1000;
           console.log(`Retry ${attempt + 1}/${maxRetries} for README: ${ocabundle} after ${Math.round(delay)}ms`);
           await new Promise(resolve => setTimeout(resolve, delay));
           continue;

--- a/app/lib/data.ts
+++ b/app/lib/data.ts
@@ -42,11 +42,18 @@ export interface BundleFilters {
 }
 
 // Cache for README content to avoid repeated fetches
+// Includes timestamp for TTL-based expiration
 const readmeCache = new Map<string, {
   ledger?: string;
   ledgerUrl?: string;
   ledgerMap?: Map<string, { ledger: string; ledgerUrl?: string }>;
+  timestamp: number;
 }>();
+
+// Cache TTL for successful README fetches: 10 minutes
+const README_CACHE_TTL = 10 * 60 * 1000;
+// Cache TTL for failed README fetches: 30 seconds (short to allow retry later)
+const README_FAIL_CACHE_TTL = 30 * 1000;
 
 // Cache for bundle list to ensure consistency across generateStaticParams and page rendering
 let bundleListCache: {
@@ -307,13 +314,22 @@ export async function fetchSchemaReadme(ocabundle: string): Promise<{
   ledgerUrl?: string;
   ledgerMap?: Map<string, { ledger: string; ledgerUrl?: string }>;
 }> {
-  // Check cache first
+  const now = Date.now();
+
+  // Check cache first (with TTL expiration)
   if (readmeCache.has(ocabundle)) {
-    return readmeCache.get(ocabundle)!;
+    const cached = readmeCache.get(ocabundle)!;
+    const cacheAge = now - cached.timestamp;
+    const ttl = cached.ledgerMap ? README_CACHE_TTL : README_FAIL_CACHE_TTL;
+    if (cacheAge < ttl) {
+      return { ledger: cached.ledger, ledgerUrl: cached.ledgerUrl, ledgerMap: cached.ledgerMap };
+    }
+    // Cache expired, remove it
+    readmeCache.delete(ocabundle);
   }
 
-  // Retry logic for failed fetches
-  const maxRetries = 2;
+  // Retry logic for failed fetches with exponential backoff
+  const maxRetries = 3;
   let lastError: Error | null = null;
 
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
@@ -322,48 +338,57 @@ export async function fetchSchemaReadme(ocabundle: string): Promise<{
       const readmePath = ocabundle.replace("OCABundle.json", "README.md");
       const readmeUrl = `${GITHUB_RAW_URL}/${readmePath}`;
 
+      // Increased timeout for CI environments (30 seconds)
+      // Use AbortSignal.timeout if available, otherwise fallback
+      const timeoutMs = 30000;
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
       const response = await fetch(readmeUrl, {
-        // Add timeout to prevent hanging requests
-        signal: AbortSignal.timeout(10000) // 10 second timeout for README files
+        signal: controller.signal as AbortSignal
       });
+
+      clearTimeout(timeoutId);
 
       if (!response.ok) {
         // Don't log 404s as they're expected for many bundles
         if (response.status !== 404) {
           console.warn(`Failed to fetch README for ${ocabundle}: ${response.status}`);
         }
-        // Don't cache failed results - return empty without caching
+        // Cache the failure briefly to avoid hammering
+        readmeCache.set(ocabundle, { timestamp: now });
         return {};
       }
 
       const readmeContent = await response.text();
       const ledgerInfo = extractLedgerFromReadme(readmeContent);
 
-      // Cache the result only if we got meaningful data
-      if (ledgerInfo.ledgerMap && ledgerInfo.ledgerMap.size > 0) {
-        readmeCache.set(ocabundle, ledgerInfo);
-      }
+      // Cache the result with timestamp (even if empty, for short period)
+      readmeCache.set(ocabundle, { ...ledgerInfo, timestamp: now });
       return ledgerInfo;
     } catch (error) {
       lastError = error instanceof Error ? error : new Error(String(error));
-      // Only retry on timeout errors
-      if (lastError.name.includes('TimeoutError')) {
+      const isTimeout = lastError.name.includes('TimeoutError') ||
+                        lastError.message.includes('aborted');
+
+      if (isTimeout) {
         if (attempt < maxRetries) {
-          console.log(`Retry ${attempt + 1}/${maxRetries} for README: ${ocabundle}`);
+          // Exponential backoff: 2s, 4s, 8s with jitter
+          const delay = (Math.pow(2, attempt) * 1000) + Math.random() * 1000;
+          console.log(`Retry ${attempt + 1}/${maxRetries} for README: ${ocabundle} after ${Math.round(delay)}ms`);
+          await new Promise(resolve => setTimeout(resolve, delay));
           continue;
         }
-        // If we've reached the max retries, fall through and let the loop end
       } else {
-        // For non-timeout errors, stop retrying immediately
+        // For non-timeout errors, log and stop retrying
+        console.warn(`Error fetching README for ${ocabundle}:`, lastError.message);
         break;
       }
     }
   }
 
-  // Don't cache failed results - return empty without caching
-  if (lastError && !lastError.name.includes('TimeoutError')) {
-    console.warn(`Error fetching README for ${ocabundle}:`, lastError.message);
-  }
+  // Cache the failure briefly
+  readmeCache.set(ocabundle, { timestamp: now });
   return {};
 }
 

--- a/app/lib/data.ts
+++ b/app/lib/data.ts
@@ -388,7 +388,7 @@ export async function fetchSchemaReadme(ocabundle: string): Promise<{
   }
 
   // Cache the failure briefly
-  readmeCache.set(ocabundle, { timestamp: now });
+  readmeCache.set(ocabundle, { timestamp: Date.now() });
   return {};
 }
 

--- a/app/lib/data.ts
+++ b/app/lib/data.ts
@@ -374,7 +374,7 @@ export async function fetchSchemaReadme(ocabundle: string): Promise<{
       if (isTimeout) {
         if (attempt < maxRetries) {
           // Exponential backoff: 2s, 4s, 8s with jitter
-          const delay = (Math.pow(2, attempt) * 1000) + Math.random() * 1000;
+          const delay = (Math.pow(2, attempt + 1) * 1000) + Math.random() * 1000;
           console.log(`Retry ${attempt + 1}/${maxRetries} for README: ${ocabundle} after ${Math.round(delay)}ms`);
           await new Promise(resolve => setTimeout(resolve, delay));
           continue;
@@ -515,11 +515,12 @@ export async function fetchOverlayBundleList(): Promise<BundleWithLedger[]> {
                     ledgerNormalized: normalized
                   };
                 } else {
-                  // Fallback: use the ledger's own info
+                  // Fallback: use the README's default ledger info, not the group's ledger
+                  // This handles cases where an ID wasn't found in ledgerInfo.ledgerMap
                   idLedgerMap[id] = {
-                    ledger: ledgerData.ledger,
-                    ledgerUrl: ledgerData.ledgerUrl,
-                    ledgerNormalized: ledgerNormalized
+                    ledger: ledgerInfo.ledger || 'unknown',
+                    ledgerUrl: ledgerInfo.ledgerUrl,
+                    ledgerNormalized: normalizeLedgerValue(ledgerInfo.ledger)
                   };
                 }
               }

--- a/app/lib/data.ts
+++ b/app/lib/data.ts
@@ -159,11 +159,11 @@ function getLedgerExplorerUrl(ledgerNormalized: string | undefined): string | un
 
   switch (ledgerNormalized) {
     case "candy-prod":
-      return "https://candyscan.idlab.org/home/CANDY_PROD";
+      return "https://candyscan.digitaltrust.gov.bc.ca/home/CANDY_PROD";
     case "candy-dev":
-      return "https://candyscan.idlab.org/home/CANDY_DEV";
+      return "https://candyscan.digitaltrust.gov.bc.ca/home/CANDY_DEV";
     case "candy-test":
-      return "https://candyscan.idlab.org/home/CANDY_TEST";
+      return "https://candyscan.digitaltrust.gov.bc.ca/home/CANDY_TEST";
     case "bcovrin-test":
       return "https://indyscan.bcovrin.vonx.io/home/BCOVRIN_TEST";
     default:
@@ -948,6 +948,19 @@ export function getAvailableLedgerOptions(bundles: BundleWithLedger[]): LedgerOp
   });
 
   return options;
+}
+
+// Determine if a ledger is a production ledger
+export function isProductionLedger(ledgerNormalized: string | undefined): boolean {
+  if (!ledgerNormalized) return false;
+  const prodLedgers = ['candy-prod', 'sovrn-mainnet', 'mainnet', 'prod'];
+  return prodLedgers.some(prod => ledgerNormalized.toLowerCase().includes(prod));
+}
+
+// Determine if a ledger is a non-production (dev/test) ledger
+export function isNonProductionLedger(ledgerNormalized: string | undefined): boolean {
+  if (!ledgerNormalized) return false;
+  return !isProductionLedger(ledgerNormalized);
 }
 
 // Filter bundles based on search criteria


### PR DESCRIPTION
## Summary
- Add drop shadow to OCA rendered cards for better visual prominence
- Replace expandable ID popup with inline chip bar showing SchemaID/CredDefID
- Copy to clipboard with WCAG-compliant text feedback
- Sort ledger accordions: production ledgers first with larger/more prominent styling
- Add TEST/DEV warning badge for non-production ledgers
- Theme-aware styling using MUI palette instead of hardcoded colors
- Update candyscan URLs to digitaltrust.gov.bc.ca

## Testing
- [ ] Verify cards display with shadow
- [ ] Verify chips show SchemaID/CredDefID labels
- [ ] Click chip to copy ID, verify Copied! feedback
- [ ] Verify production ledgers appear first and expanded
- [ ] Verify non-production ledgers show TEST/DEV badge and are muted